### PR TITLE
Use get_authenticated_user.

### DIFF
--- a/duoauthenticator/duoauthenticator.py
+++ b/duoauthenticator/duoauthenticator.py
@@ -123,8 +123,8 @@ class DuoAuthenticator(Authenticator):
 
         Return None otherwise.
         """
-        primary_username = await self.primary_authenticator.authenticate(handler, data)
-        if primary_username:
-            return primary_username
+        user = await self.primary_authenticator.get_authenticated_user(handler, data)
+        if user:
+            return user['name']
         else:
             return None


### PR DESCRIPTION
This avoids bypassing normalization and validation.

See https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.get_authenticated_user. By calling `authenticate(...)` directly, the `DuoAuthenticator` was not giving the primary auth the opportunity to run its normalize sequence of normalization and validation steps.